### PR TITLE
Don't suggest token reuse for double-puppeting

### DIFF
--- a/bridges/general/double-puppeting.md
+++ b/bridges/general/double-puppeting.md
@@ -19,9 +19,6 @@ the normal login, you must do this in a private chat with the bridge bot.
    ```shell
    $ curl -XPOST -d '{"type":"m.login.password","identifier":{"type": "m.id.user", "user": "example"},"password":"wordpass","initial_device_display_name":"a fancy bridge"}' https://example.com/_matrix/client/r0/login
    ```
-   Alternatively, you can get an existing access token from your client
-   (Settings -> Help & About in Element Web/Desktop). However, this means
-   double puppeting will break if you log out of that client.
 2. Send `login-matrix <access token>` to the bridge bot. For the Telegram
    bridge, send `login-matrix` without the access token, then send the access
    token in a separate message.


### PR DESCRIPTION
While this mostly works, it means that there are now two clients A and B acting
as the same logical [device]. The two clients are indistinguishable to a
homeserver.  Since to_device messages are delivered [exactly once] to each
device, this means that there's a race between A and B to receive and
acknowledge to_device messages. In the worst case, this can mean that one
client can "miss" to_device messages. (See matrix-org/synapse#9533), and
in particular [this comment](https://github.com/matrix-org/synapse/issues/9533#issuecomment-902928976).

Instead, each client should register a unique (private) access token so that it
appears as a unique device to the homeserver. See also [client authentication]
in the spec.

[device]: https://matrix.org/docs/spec/index#devices
[exactly once]: https://matrix.org/docs/spec/client_server/r0.6.1#id70
[client authentication]: https://matrix.org/docs/spec/client_server/r0.6.1#client-authentication