### PR TITLE
Update docs for running mautrix-signal as unprivileged user

### DIFF
--- a/bridges/python/signal/setup-docker.md
+++ b/bridges/python/signal/setup-docker.md
@@ -12,6 +12,7 @@
   updated to match the maunium image.
 * By default, the bridge runs as root. You can run it as a different user, but
   make sure you `chown` all the files and make signald run as the same user.
+  Additionally set the log file to a path where the user is able to write (e.g. `/data/`).
 
 ## Setup
 0. Create a directory for the bridge and cd into it: `mkdir mautrix-signal && cd mautrix-signal`.


### PR DESCRIPTION
The default log path for running it in a docker container is /opt/mautrix-signal/mautrix-signal.log
Other users aren't allowed to write in this directory causing issues on startup