### PR TITLE
Update signald docker image name.

### DIFF
--- a/bridges/python/signal/setup-docker.md
+++ b/bridges/python/signal/setup-docker.md
@@ -49,7 +49,7 @@
 
      signald:
        container_name: signald
-       image: docker.io/finn/signald
+       image: docker.io/signald/signald
        restart: unless-stopped
        volumes: 
        - ./signald:/signald


### PR DESCRIPTION
As per https://hub.docker.com/r/finn/signald, the image was moved to `signald/signald`.