### PR TITLE
Login, read receipts, and typing notification docs for iMessage on nosip

### DIFF
--- a/bridges/go/imessage/mac-nosip/setup.md
+++ b/bridges/go/imessage/mac-nosip/setup.md
@@ -78,6 +78,9 @@ You can also refer to Apple's [official documentation on disabling SIP](https://
 3. In the `imessage` section of the config, change `platform` to `mac-nosip`
    and set `imessage_rest_path` to the path to the `darwin-barcelona-mautrix`
    executable you downloaded or compiled.
-4. Run the bridge with `./mautrix-imessage`.
+4. If you want messages sent directly from iMessage to be replicated on Matrix (have the puppet work), you'll need to set up the [shared secret] plugin for Synapse (there may exist other ways to do this using `login-matrix` but the iMessage bridge doesn't seem to support this at the moment). Once you generate a shared secret, use the same secret in the `login_shared_secret` section in the `bridge` section of `config.yaml`. It's worth noting the `m_login_password_setup_enabled` should be `true` when setting up the shared secret plugin.
+5. If you'd like to enable read receipts to be sent from Matrix to iMessage after you've set up the puppet, set the `delivery_receipts` in the `bridge` section to `true`. If you'd like to enable typing indicators from Matrix to iMessaage, you should set `sync_with_custom_puppets` to `true` in the `bridge` section.
+6. Run the bridge with `./mautrix-imessage`.
 
 [com.apple.security.xpc.plist]: https://github.com/open-imcore/barcelona/blob/mautrix/com.apple.security.xpc.plist
+[shared secret]: https://github.com/devture/matrix-synapse-shared-secret-auth


### PR DESCRIPTION
When I was setting up the Mautrix iMessage bridge for nosip I encountered some difficulties getting typing indicators and puppeting to work due to a lack of documentation. Anyway, I wanted to document these things since hopefully it would make them easier for future users setting up this bridge.

My PR just adds a couple of points on how to enable read receipts and that you need the custom puppet enabled if you want typing indicators to work. It also has documentation about how to log in for puppeting, but I'm not sure if the `login-matrix` stuff is right. 

I'm not too sure about the contribution guidelines to this repo, so feel free to reject this or comment on any changes that need to be made.

Thanks!