### PR TITLE
Add hardening options to systemd unit

### DIFF
--- a/bridges/python/setup/systemd.md
+++ b/bridges/python/setup/systemd.md
@@ -20,6 +20,25 @@
    ExecStart=/opt/mautrix-$bridge/bin/python -m mautrix_$bridge
    User=mautrix-$bridge
 
+   # Hardening
+   CapabilityBoundingSet = [ "" ];
+   LockPersonality = true;
+   PrivateTmp = true;
+   ProcSubset = "pid";
+   ProtectClock = true;
+   ProtectControlGroups = true;
+   ProtectHome = true;
+   ProtectHostname = true;
+   ProtectKernelLogs = true;
+   ProtectKernelModules = true;
+   ProtectKernelTunables = true;
+   ProtectProc = "invisible";
+   ProtectSystem = "strict";
+   RestrictNamespaces = true;
+   RestrictRealtime = true;
+   RestrictSUIDSGID = true;
+   SystemCallArchitectures = "native";
+
    [Install]
    WantedBy=multi-user.target
    ```


### PR DESCRIPTION
These options increase the isolation of `mautrix-*` system services.

I have been using these options with mautrix-telegram without issues (on NixOS 21.11).

I am not setting `SystemCallFilter` as it might cause issue with old systemd distributions such as Ubuntu 18.04.
I am not setting `DeviceAllow`, `PrivateDevices`, `PrivateUsers`, `RestrictAddressFamilies` and `UMask` as I have not enough knowledge about how other mautrix bridges could behave.

Thanks,