### PR TITLE
Update encryption dependency

### DIFF
--- a/maubot/usage/encryption.md
+++ b/maubot/usage/encryption.md
@@ -4,6 +4,7 @@
 To enable encryption, you must first have maubot installed with the `e2be`
 optional dependency. To do this, you can either add `[e2be]` at the end of the
 package in the `pip install` command, e.g. `pip install --upgrade maubot[e2be]`.
+Your system will need to have `libolm` installed for this to work.
 Alternatively, you can install the dependencies manually (`asyncpg`,
 `python-olm`, `pycryptodome` and `unpaddedbase64`). The Docker image has all
 optional dependencies installed by default.

--- a/maubot/usage/encryption.md
+++ b/maubot/usage/encryption.md
@@ -4,9 +4,9 @@
 To enable encryption, you must first have maubot installed with the `e2be`
 optional dependency. To do this, you can either add `[e2be]` at the end of the
 package in the `pip install` command, e.g. `pip install --upgrade maubot[e2be]`.
-Your system will need to have `libolm` installed for this to work.
-Alternatively, you can install the dependencies manually (`asyncpg`,
-`python-olm`, `pycryptodome` and `unpaddedbase64`). The Docker image has all
+Your system will need to have `libolm` installed for this to work. Alternatively,
+you can install the dependencies manually (`asyncpg`, `python-olm`,
+`pycryptodome`, `unpaddedbase64` and `wheel`). The Docker image has all
 optional dependencies installed by default.
 
 ## Getting a fresh device ID


### PR DESCRIPTION
Not sure if this would be a helpful add to the docs. Ran into this when trying to enable encryption.

If `libolm` is not installed on the system first, pip will fail to install at `python-olm`, saying that olm cannot be found.