### PR TITLE
Encryption: Add instructions for macOS

### DIFF
--- a/maubot/usage/encryption.md
+++ b/maubot/usage/encryption.md
@@ -21,6 +21,12 @@ work at all.
 pip install python-olm --extra-index-url https://gitlab.matrix.org/api/v4/projects/27/packages/pypi/simple
 ```
 
+To install python-olm on macOS, you can use libolm from homebrew like this:
+```
+brew install libolm
+pip3 install python-olm --global-option="build_ext" --global-option="--include-dirs=/opt/homebrew/opt/libolm/include" --global-option="--library-dirs=/opt/homebrew/opt/libolm/lib"git st
+```
+
 ## Getting a fresh device ID
 When using maubot with encryption, you must have an access token and a device ID
 that haven't been used in an e2ee-capable client. In other words, you can't take

--- a/maubot/usage/encryption.md
+++ b/maubot/usage/encryption.md
@@ -24,7 +24,7 @@ pip install python-olm --extra-index-url https://gitlab.matrix.org/api/v4/projec
 To install python-olm on macOS, you can use libolm from homebrew like this:
 ```
 brew install libolm
-pip3 install python-olm --global-option="build_ext" --global-option="--include-dirs=/opt/homebrew/opt/libolm/include" --global-option="--library-dirs=/opt/homebrew/opt/libolm/lib"git st
+pip3 install python-olm --global-option="build_ext" --global-option="--include-dirs="`brew --prefix libolm`"/include" --global-option="--library-dirs="`brew --prefix libolm`"/lib"
 ```
 
 ## Getting a fresh device ID


### PR DESCRIPTION
The `pip install` command needs to be extended to pass the include and lib path of libolm installed via homebrew which has been non-trivial to discover for me.