### PR TITLE
fix nginx config example

### DIFF
--- a/maubot/usage/setup/reverse-proxy.md
+++ b/maubot/usage/setup/reverse-proxy.md
@@ -28,6 +28,7 @@ server {
 
     location /_matrix/maubot {
         proxy_pass http://localhost:29316;
+        proxy_http_version 1.1;
         proxy_set_header X-Forwarded-For $remote_addr;
     }
     ...


### PR DESCRIPTION
without the proxy_http_version set to 1.1 version the avatar upload calls fail in the frontend with an NS_ERROR_NET_INTERRUPT error in Firefox so the resulting media id does not get propagated in the avatar field. This small config adjustment fixes this issue.