### PR TITLE
Update caddy config in reverse-proxy doc to forward the correct path

### DIFF
--- a/maubot/usage/setup/reverse-proxy.md
+++ b/maubot/usage/setup/reverse-proxy.md
@@ -9,7 +9,7 @@ Caddy 2 supports websockets out of the box with no additional configuration.
 
 ```Caddyfile
 example.com {
-    reverse_proxy /_matrix/maubot http://localhost:29316
+    reverse_proxy /_matrix/maubot/* http://localhost:29316
 }
 ```
 


### PR DESCRIPTION
Without appending the catch-all `/*` to the end of `/_matrix/maubot` caddy will proxy *only* that path, however for the maubot interface to function all paths under `/_matrix/maubot/` should be forwarded, otherwise the static files required for the interface to function cannot be loaded from the server.
