### PR TITLE
Remove SNT from public Telegram instances

### DIFF
--- a/bridges/python/telegram/index.md
+++ b/bridges/python/telegram/index.md
@@ -17,8 +17,6 @@ rooms.
   (only relay bridging, puppeting is disabled)
 * [tchncs.de](https://tchncs.de/matrix)
   / [#tchncs:tchncs.de](https://matrix.to/#/#tchncs:tchncs.de)
-* [snt.utwente.nl](https://syscom.utwente.io/info/matrix/telegram/)
-  / [#telegram:utwente.io](https://matrix.to/#/#telegram:utwente.io)
 
 If you run a public instance and wish to list it here, please [make a pull request](https://github.com/mautrix/docs/blob/master/bridges/python/telegram/index.md).
 


### PR DESCRIPTION
SNT is stopping their public Telegram bridge due to resource constraints and a lack of manpower.
